### PR TITLE
Fix for making installed packages configurable (especially Java).

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,9 @@ logstash_apt_repositories:                  # These repositories will be added t
 - deb http://packages.elasticsearch.org/logstash/1.4/debian stable main
 - deb http://packages.elasticsearch.org/logstashforwarder/debian stable main
 logstash_apt_key: http://packages.elasticsearch.org/GPG-KEY-elasticsearch
-logstash_apt_pkgs:
+logstash_apt_common_pkgs:
 - acl
 - oracle-java7-installer
-- logstash
-- logstash-contrib
 
 logstash_server_enabled: yes                # Setup logstash server
 logstash_forwarder_enabled: no              # Setup logstash forwarder

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,11 +6,9 @@ logstash_apt_repositories:                  # These repositories will be added t
 - deb http://packages.elasticsearch.org/logstash/1.4/debian stable main
 - deb http://packages.elasticsearch.org/logstashforwarder/debian stable main
 logstash_apt_key: http://packages.elasticsearch.org/GPG-KEY-elasticsearch
-logstash_apt_pkgs:
+logstash_apt_common_pkgs:
 - acl
 - oracle-java7-installer
-- logstash
-- logstash-contrib
 
 logstash_server_enabled: yes                # Setup logstash server
 logstash_forwarder_enabled: no              # Setup logstash forwarder

--- a/tasks/install.deb.yml
+++ b/tasks/install.deb.yml
@@ -13,9 +13,7 @@
 
 - name: logstash-install | Install commmon packages
   apt: pkg={{item}}
-  with_items:
-  - acl
-  - oracle-java7-installer
+  with_items: logstash_apt_common_pkgs
 
 - name: logstash-install | Install logstash
   apt: pkg={{item}}


### PR DESCRIPTION
This very minor PR puts `logstash_apt_pkgs` into actual use, allowing e.g. to skip the previously mandatory Java installation, which might be unnecessary in some cases.