### PR TITLE
Don't install unnecessary logstash parts when configured as disabled

### DIFF
--- a/tasks/install.deb.yml
+++ b/tasks/install.deb.yml
@@ -15,6 +15,7 @@
 - name: logstash-install | Download logstash
   get_url: url={{logstash_url}} dest={{logstash_home}}/logstash.deb
   register: logstash_downloaded
+  when: logstash_server_enabled or logstash_web_enabled
 
 - name: logstash-install | Install logstash
   apt: deb={{logstash_home}}/logstash.deb


### PR DESCRIPTION
This prevents from installing packages as well as setting up upstart services for e.g. logstash server and logstash web when they were configured to be disabled in role. Same with forwarder.

The issue I had was: hen only forwarder was enabled, I was getting server and web installed too (although it was not necessary). As a consequence there were upstart scripts setup that were trying to bring non-configured logstash server on start (which was failing constantly - upstart respawns).

Now when there is only forwarder enabled, it doesn't install core logstash package (and vice versa).